### PR TITLE
fix typo in meta description

### DIFF
--- a/overview.html
+++ b/overview.html
@@ -11,7 +11,7 @@
     <meta name="twitter:title" content="W3C Workshop on WCG &amp; HDR for the Web">
     <meta property="og:title" content="W3C Workshop on WCG &amp; HDR for the Web">
     <meta name="twitter:image" content="https://www.w3.org/Graphics/Color/Workshop/media/twitter-banner.png">
-    <meta property="og:description" content="W3C Workshop on Wide Color Gamut (WCG) &amp; Hight Dynamic Range (HDR) for the Web">
+    <meta property="og:description" content="W3C Workshop on Wide Color Gamut (WCG) &amp; High Dynamic Range (HDR) for the Web">
     <meta property="og:image" content="https://www.w3.org/Graphics/Color/Workshop/media/twitter-banner.png">
   </head>
   <body>


### PR DESCRIPTION
there was a typo in the og:description meta tag that I caught on twitter, so here we are :)